### PR TITLE
Networks with fix

### DIFF
--- a/openpathsampling/storage/object_storage.py
+++ b/openpathsampling/storage/object_storage.py
@@ -1329,13 +1329,17 @@ def saveidx(func):
         if self.has_uid and hasattr(obj, '_uid') and obj._uid != '':
             self.storage.variables[self.identifier][idx] = obj._uid
 
-        if self.has_uid and hasattr(obj, '_name'):
+        if self.has_name and hasattr(obj, '_name'):
             #logger.debug('Object ' + str(type(obj)) + ' with IDX #' + str(idx))
             #logger.debug(repr(obj))
             #logger.debug("Cleaning up name; currently: " + str(obj._name))
             if obj._name is None:
-                # set name of object to empty string
-                obj.fix_name()
+                # this should not happen!
+                logger.debug("Nameable object has not been initialized correctly. Has None in _name")
+                raise AttributeError('_name needs to be a string for nameable objects.')
+                obj._name = ''
+
+            obj.fix_name()
 
             self.storage.variables[self.db + '_name'][idx] = obj._name
 

--- a/openpathsampling/topology.py
+++ b/openpathsampling/topology.py
@@ -60,7 +60,7 @@ class MDTrajTopology(Topology):
 
     def to_dict(self):
         out = dict()
-        used_elements = set()
+        # used_elements = set()
 
         atom_data = []
         for atom in self.md.atoms:
@@ -73,30 +73,30 @@ class MDTrajTopology(Topology):
                          int(atom.residue.resSeq), atom.residue.name,
                          atom.residue.chain.index))
 
-            used_elements.add(atom.element)
+            # used_elements.add(atom.element)
 
         out['atom_columns'] = ["serial", "name", "element", "resSeq", "resName", "chainID"]
         out['atoms'] = atom_data
         out['bonds'] = [(a.index, b.index) for (a, b) in self.md.bonds]
-        out['elements'] = {key: tuple(el) for key, el in md.element.Element._elements_by_symbol.iteritems() if el in used_elements}
+        # out['elements'] = {key: tuple(el) for key, el in md.element.Element._elements_by_symbol.iteritems() if el in used_elements}
 
         return {'md' : out, 'subsets' : self.subsets}
 
     @classmethod
     def from_dict(cls, dct):
         top_dict = dct['md']
-        elements = top_dict['elements']
+        # elements = top_dict['elements']
 
-        for key, el in elements.iteritems():
-            try:
-                md.element.Element(
-                            number=int(el[0]), name=el[1], symbol=el[2], mass=float(el[3])
-                         )
-                simtk.openmm.app.Element(
-                            number=int(el[0]), name=el[1], symbol=el[2], mass=float(el[3])*units.amu
-                         )
-            except(AssertionError):
-                pass
+        # for key, el in elements.iteritems():
+        #     try:
+        #         md.element.Element(
+        #                     number=int(el[0]), name=el[1], symbol=el[2], mass=float(el[3])
+        #                  )
+        #         simtk.openmm.app.Element(
+        #                     number=int(el[0]), name=el[1], symbol=el[2], mass=float(el[3])*units.amu
+        #                  )
+        #     except(AssertionError):
+        #         pass
 
         atoms = pd.DataFrame(top_dict['atoms'], columns=top_dict['atom_columns'])
         bonds = np.array(top_dict['bonds'])


### PR DESCRIPTION
This fixes a problem with named objects and also changes the way topologies are stored to be compatible with newer mdtraj versions.

Basically it removes the option to save new elements, which was introduced before to allow storage of ToyDynamics. The current implementation specifically uses two Topology objects to handle this so the element saving is not necessary anymore.